### PR TITLE
Add reactor core system detail view

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -405,6 +405,106 @@ body {
     margin: 0;
 }
 
+.detail-section {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 0.75rem;
+    margin-top: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.detail-section h4 {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8rem;
+}
+
+.data-table th,
+.data-table td {
+    text-align: left;
+    padding: 0.35rem 0.4rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.data-table th {
+    color: var(--accent);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.reactor-modes {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.reactor-mode {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.reactor-mode header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.reactor-mode h5 {
+    margin: 0;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+}
+
+.mode-output {
+    font-size: 0.8rem;
+    color: var(--accent-strong);
+    font-weight: 600;
+}
+
+.mode-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+.detail-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+}
+
+.detail-list.ordered {
+    list-style: decimal;
+}
+
+.detail-list:not(.ordered) {
+    list-style: disc;
+}
+
+.detail-list li strong {
+    color: var(--accent);
+    font-weight: 600;
+}
+
 .app-footer {
     position: sticky;
     bottom: 0;

--- a/assets/js/modules/data.js
+++ b/assets/js/modules/data.js
@@ -1,5 +1,62 @@
 export const SHIP_SYSTEMS = [
     {
+        id: 'reactor',
+        name: 'Reaktorkern',
+        status: 'online',
+        power: 92,
+        integrity: 93,
+        load: 81,
+        details: {
+            beschreibung: 'Quantenfusion-Reaktorkern als zentrale Energiequelle des Schiffes.',
+            redundanz: 'Dual-Plasmaeinspeisung mit separatem Notfall-Materie/Antimaterie-Puffer',
+            letzteWartung: 'Stardate 4523.8',
+            sensors: [
+                'Magnetfeld-Kohärenz 99.7% stabil',
+                'Kernplasma 14.2 keV',
+                'Primärer Kühlkreislauf Druck 1.8 MPa'
+            ],
+            outputCurve: [
+                { load: '0–20%', output: '0.6 TW', notes: 'Grundlast für Lebenserhaltung & Standby-Systeme' },
+                { load: '21–60%', output: '1.3 TW', notes: 'Nominaler Flug- und Schiffsbetrieb' },
+                { load: '61–90%', output: '2.1 TW', notes: 'Warpfeld-Speisung & Hochlastmanöver' },
+                { load: '91–105%', output: '2.6 TW', notes: 'Notfall-Boost < 90 Sekunden' }
+            ],
+            efficiencyHeat: [
+                { mode: 'Eco', efficiency: '97%', heat: '340 MJ/min', coolant: '50% Kühlschleifen aktiv' },
+                { mode: 'Nominal', efficiency: '94%', heat: '520 MJ/min', coolant: '68% Kühlschleifen aktiv' },
+                { mode: 'Burst', efficiency: '88%', heat: '910 MJ/min', coolant: '100% + Entlastungsventile' }
+            ],
+            modes: [
+                {
+                    name: 'Eco',
+                    output: '0.7 TW',
+                    duration: 'unbegrenzt',
+                    description: 'Stabile Grundlast für Bereitschaftszustände, automatische Leistungsdämpfung aktiv.',
+                    advisories: 'Empfohlen in Dock, Orbit oder während Wartung.'
+                },
+                {
+                    name: 'Burst',
+                    output: '2.4 TW',
+                    duration: 'max. 90 Sekunden',
+                    description: 'Kurzzeitiger Leistungsschub für Gefechts- oder Fluchtmanöver, führt zu erhöhter Hitze.',
+                    advisories: 'Nur in Alarmstufen Gelb/Rot freigegeben, Nachkühlphase erforderlich.'
+                }
+            ],
+            failureScenarios: [
+                { title: 'Injektor-Phasendrift', mitigation: 'Magnetfeld neu synchronisieren und Leistung um 15% reduzieren.' },
+                { title: 'Kühlmittel-Überdruck', mitigation: 'Sekundärkreislauf öffnen, Entlastungsventile testen, Technikteam alarmieren.' },
+                { title: 'Containment-Flackern', mitigation: 'Reaktor auf Eco herunterschalten, Abschirmfeld verstärken, Crew evakuationsbereit halten.' }
+            ],
+            startSequence: [
+                'Materie-/Antimaterie-Schotts schließen und verriegeln.',
+                'Magnetfeld-Vorkühlung hochfahren und Stabilität prüfen.',
+                'Plasma-Injektoren entlüften und automatisch kalibrieren lassen.',
+                'Reaktionskammer auf 1% Leistung entzünden und Spektrum überwachen.',
+                'Leistung stufenweise auf 35% erhöhen, Notabschaltung scharf schalten.'
+            ]
+        }
+    },
+    {
         id: 'life-support',
         name: 'Lebenserhaltung',
         status: 'online',


### PR DESCRIPTION
## Summary
- add a dedicated Reaktorkern entry with output curve, efficiency and operation data
- render reactor-specific output, mode, failure and start sequence sections in the system inspector
- style the inspector detail sections for tables, mode cards and lists

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbee22aa848326973836ab289ccca8