### PR TITLE
Add thermal control task checklist

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,12 @@
 - [ ] Autorisierungen für kritische Aktionen verwalten.
 - [ ] Audit-Trail auf Vollständigkeit und Manipulation prüfen.
 
+### Thermal Control
+- [ ] Wärmestau-Analysen mit Hotspot-Priorisierung etablieren.
+- [ ] Radiatorenwinkel, Segmentierung und Pumpen dynamisch regeln.
+- [ ] Signaturmanagement zwischen Abstrahlung und Tarnung abstimmen.
+- [ ] Notkühlungs- und Abschaltprotokolle trainieren und dokumentieren.
+
 ## Phase 5 – Brücke, Stationen, UX
 
 ### Stations/Consoles

--- a/docs/thermal-control.md
+++ b/docs/thermal-control.md
@@ -1,0 +1,27 @@
+# Thermal Control – Aufgabenübersicht
+
+Die Thermalkontrolle des Schiffes balanciert Wärmeerzeugung, Kühlketten und die sichtbare Signatur. Die folgenden Aufgaben helfen der Engineering-Crew, Überhitzung zu vermeiden und taktische Vorgaben einzuhalten.
+
+## Wärmestau analysieren und vermeiden
+- Sensorcluster für Reaktor, Triebwerke und Hochenergieverbraucher überwachen.
+- Hotspots kartieren und Prioritäten für Umverteilung oder Drosselung vergeben.
+- Wärmepuffer (Kühlmittel, Phasenwechselmaterialien) auf Kapazität und Status prüfen.
+- Frühwarnschwellen festlegen, damit die Brücke rechtzeitig Lastumschichtungen veranlasst.
+
+## Radiatorensteuerung optimieren
+- Ausfahrwinkel, Segmentierung und Pumpendrehzahlen der Radiatoren dynamisch anpassen.
+- Mikro-Meteoritenschutz und Notabdichtung berücksichtigen, bevor Radiatoren erweitert werden.
+- Energiezuteilung mit dem Power-Management abstimmen, um Spitzenlasten zu glätten.
+- Automatische Diagnose nutzen, um defekte Panels oder Förderkreise zu isolieren.
+
+## Abstrahlung vs. Signatur abwägen
+- Wärmeabstrahlung gegen sensorische Tarnung vergleichen (IR, EM, Partikelspuren).
+- Missionsparameter (Stealth, Gefecht, Reiseflug) heranziehen, um Zielwerte zu definieren.
+- Abschirmungen, Emissionsumlenkung und falsche Zielsignaturen mit der Taktik koordinieren.
+- Brückenkonsolen mit Live-Signaturplots versorgen, damit Entscheidungen nachvollziehbar bleiben.
+
+## Notkühlung vorbereiten
+- CO₂- und Kryo-Bypässe testen, um schnelle Temperaturabsenkungen zu ermöglichen.
+- Kühlmittelreserven für Feuerbekämpfung, Reaktor-Scram und Lebenserhaltung reservieren.
+- Mobile Heat-Sinks und Transferleitungen auf Bereitschaft halten.
+- Evakuierungs- und Abschaltprotokolle für kritische Sektoren dokumentieren und trainieren.


### PR DESCRIPTION
## Summary
- add a dedicated thermal control checklist covering heat buildup, radiator management, signature balance, and emergency cooling
- extend the roadmap with a Thermal Control section that highlights the key work packages

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbee2d1db48326be398e727c823066