### PR TITLE
Add sub-light propulsion checklist

### DIFF
--- a/docs/propulsion-sub-light.md
+++ b/docs/propulsion-sub-light.md
@@ -1,0 +1,33 @@
+# Propulsion (Sub-Light) – Aufgabenübersicht
+
+Der Sublight-Antrieb liefert den Schub für Navigation, Gefechtsmanöver und Feinpositionierung. Die folgende Aufgabenliste richtet sich an Pilot:innen und Engineering, um Triebwerkseffizienz, Sicherheit und Reaktionsfähigkeit sicherzustellen.
+
+## Schubmanagement
+- Schubkurven und Leistungsreserven der Haupt- und Manövriertriebwerke überwachen.
+- Schubanforderungen mit dem Brückenkurs und den Energiezuweisungen abstimmen.
+- Temperatur- und Vibrationssensoren für Anzeichen von Instabilitäten beobachten.
+- Schubspitzen dokumentieren, um Wartungsintervalle und Lebensdauer zu planen.
+
+## Treibstofflogistik
+- Verbrauchsraten in Echtzeit erfassen und gegen Missionsbudget abgleichen.
+- Transferleitungen und Pumpendruck zwischen Tanks testen und kalibrieren.
+- Injektoren, Filter und Verdichter auf Verunreinigung oder Kavitation prüfen.
+- Reservekontingente für Notmanöver, Start-/Landesequenzen und Stromausfälle sichern.
+
+## Trägheits- und Massemanagement
+- Aktuelle Masseverteilung, Schwerpunktlage und Trägheitsmoment aus Sensor- und Frachtmeldungen konsolidieren.
+- Anpassungen des Reaktionsregelungssystems (RCS) bei strukturellen Änderungen einspielen.
+- Trägheitskompensatoren und Dämpfungsfelder auf Drift, Latenz und Fehlersignale prüfen.
+- Simulationsdaten der Navigation nutzen, um Limits für enge Kurven oder abrupte Stopps zu kommunizieren.
+
+## Manöverprofile
+- Standardprofile (Cruise, Patrol, Intercept, Evasive) mit Sollwerten für Schub, Pitch/Yaw/Roll und RCS-Einsatz pflegen.
+- Missionsspezifische Sequenzen (Docking, Formationsflug, Asteroidenfeld) mit Sensor- und Taktikdaten abstimmen.
+- Übersichtsdiagramme bereitstellen, damit Pilot:innen Soll-/Ist-Abweichungen schnell erkennen.
+- Nachbesprechungen protokollieren, um Profile anhand realer Flugdaten zu verfeinern.
+
+## Drosselung und Feinregelung
+- Drosselventile, Plasmaeinspritzung und Feldkonverter für sanfte Übergänge konfigurieren.
+- Mikroimpulse für Positionierung, Abbremsen und Rotationsausgleich testen.
+- PID-/Adaptive-Reglerparameter mit Telemetrie kalibrieren, um Overshoot zu vermeiden.
+- Automatik- und manuellen Modus regelmäßig gegen Checklisten verifizieren.


### PR DESCRIPTION
## Summary
- add a Propulsion (Sub-Light) Aufgabenübersicht with actionable checklisten for Schub, Treibstoff, Trägheit und Feinregelung

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cbee3042d48326a9e81a2670a5c26c