### PR TITLE
Add scenario-driven engineering panels

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2171,6 +2171,61 @@ body.station-body {
     background: var(--success);
 }
 
+.operations-metric--accent .operations-meter-fill {
+    background: var(--accent);
+}
+
+.operations-metric--danger .operations-meter-fill {
+    background: var(--danger);
+}
+
+.operations-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.operations-table th,
+.operations-table td {
+    padding: 0.55rem 0.9rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    text-align: left;
+    vertical-align: top;
+}
+
+.operations-table th {
+    background: rgba(255, 255, 255, 0.04);
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+}
+
+.operations-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.operations-table strong {
+    display: block;
+    font-size: 0.95rem;
+}
+
+.operations-table small,
+.operations-subline {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.2rem;
+}
+
+.operations-subline {
+    letter-spacing: 0.02em;
+}
+
 .operations-control-list {
     display: flex;
     flex-direction: column;
@@ -2555,6 +2610,50 @@ body.station-body {
     margin: 0;
     color: var(--text-secondary);
     font-size: 0.85rem;
+}
+
+.operations-placeholder--error {
+    color: var(--danger);
+}
+
+.operations-bypass-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.operations-bypass {
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 0.8rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.operations-bypass__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.operations-bypass__title {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.operations-bypass__meta {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+}
+
+.operations-bypass__note {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
 }
 
 .station-meta {

--- a/assets/js/station-page.js
+++ b/assets/js/station-page.js
@@ -27,7 +27,7 @@ function createRelatedStations(station) {
     return related.map((item) => ({ name: item.name, htmlPath: item.htmlPath }));
 }
 
-function renderStation(stationId) {
+async function renderStation(stationId) {
     const station = getStationById(stationId);
     const titleElement = document.getElementById('station-title');
     const breadcrumb = document.getElementById('station-breadcrumb');
@@ -136,6 +136,10 @@ function renderStation(stationId) {
         );
         modules.add('assets/js/stations-data.js');
         modules.add('assets/js/station-utils.js');
+        if (canRenderOperations) {
+            modules.add('assets/js/station-operations.js');
+            modules.add('assets/js/station-scenario.js');
+        }
 
         Array.from(modules)
             .sort((a, b) => a.localeCompare(b, 'de'))
@@ -174,7 +178,7 @@ function renderStation(stationId) {
         operationsIntro.textContent = `Interaktive Bedienelemente und Anzeigen für ${station.name}.`;
     }
     if (operationsContainer) {
-        renderOperationsForStation(station, operationsContainer);
+        await renderOperationsForStation(station, operationsContainer);
     }
 }
 
@@ -184,5 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn('Keine Stations-ID am Body gefunden.');
         return;
     }
-    renderStation(stationId);
+    renderStation(stationId).catch((error) => {
+        console.error('Fehler beim Rendern der Station:', error);
+    });
 });

--- a/assets/js/station-scenario.js
+++ b/assets/js/station-scenario.js
@@ -1,0 +1,176 @@
+const SCENARIO_URL = new URL('../data/scenario-default.xml', import.meta.url).href;
+let scenarioPromise = null;
+
+export async function loadScenarioData() {
+    if (!scenarioPromise) {
+        scenarioPromise = fetch(SCENARIO_URL)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`Szenariodatei konnte nicht geladen werden (Status ${response.status})`);
+                }
+                return response.text();
+            })
+            .then((text) => parseScenarioXml(text))
+            .catch((error) => {
+                console.error('Fehler beim Laden der Szenariodatei:', error);
+                scenarioPromise = null;
+                throw error;
+            });
+    }
+    return scenarioPromise;
+}
+
+function parseScenarioXml(xmlText) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xmlText, 'application/xml');
+    const parseError = doc.querySelector('parsererror');
+    if (parseError) {
+        const message = parseError.textContent?.trim() ?? 'Unbekannter Parserfehler';
+        throw new Error(`Szenario konnte nicht gelesen werden: ${message}`);
+    }
+
+    return {
+        systems: parseSystems(doc),
+        damageControl: parseDamageControl(doc)
+    };
+}
+
+function parseSystems(doc) {
+    const systemsRoot = doc.querySelector('scenario > ship > systems');
+    if (!systemsRoot) {
+        return [];
+    }
+
+    return Array.from(systemsRoot.children)
+        .filter((child) => isTag(child, 'system'))
+        .map((systemEl) => ({
+            id: systemEl.getAttribute('id') || null,
+            name: systemEl.getAttribute('name') || getChildText(systemEl, ['name', 'bezeichnung']) || '',
+            status: (getChildText(systemEl, 'status') || systemEl.getAttribute('status') || '').toLowerCase(),
+            power: toNumber(getChildText(systemEl, 'power')),
+            integrity: toNumber(getChildText(systemEl, ['integrity', 'integritaet'])),
+            load: toNumber(getChildText(systemEl, 'load')),
+            description: getChildText(systemEl, ['beschreibung', 'description']) || '',
+            redundancy: getChildText(systemEl, ['redundanz', 'redundancy']) || '',
+            lastService: getChildText(systemEl, ['letztewartung', 'letzteWartung', 'lastservice']) || ''
+        }));
+}
+
+function parseDamageControl(doc) {
+    const damageRoot = doc.querySelector('scenario > damageControl');
+    if (!damageRoot) {
+        return { reports: [], systems: [], bypasses: [], repairs: [] };
+    }
+
+    const reports = Array.from(damageRoot.querySelectorAll('reports > report')).map((reportEl) => ({
+        id: reportEl.getAttribute('id') || null,
+        system: reportEl.getAttribute('system') || '',
+        location: reportEl.getAttribute('location') || '',
+        severity: (reportEl.getAttribute('severity') || '').toLowerCase(),
+        status: (reportEl.getAttribute('status') || '').toLowerCase(),
+        eta: reportEl.getAttribute('eta') || '',
+        note: getChildText(reportEl, 'note') || ''
+    }));
+
+    const systemsEl = findChild(damageRoot, 'systems');
+    const systems = systemsEl
+        ? Array.from(systemsEl.children)
+              .filter((child) => isTag(child, 'node'))
+              .map((node) => parseDamageNode(node))
+        : [];
+
+    const bypassesEl = findChild(damageRoot, 'bypasses');
+    const bypasses = bypassesEl
+        ? Array.from(bypassesEl.children)
+              .filter((child) => isTag(child, 'bypass'))
+              .map((bypassEl) => ({
+                  id: bypassEl.getAttribute('id') || null,
+                  description: bypassEl.getAttribute('description') || '',
+                  owner: bypassEl.getAttribute('owner') || '',
+                  status: (bypassEl.getAttribute('status') || '').toLowerCase(),
+                  eta: bypassEl.getAttribute('eta') || '',
+                  note: getChildText(bypassEl, 'note') || ''
+              }))
+        : [];
+
+    const repairsEl = findChild(damageRoot, 'repairs');
+    const repairs = repairsEl
+        ? Array.from(repairsEl.children)
+              .filter((child) => isTag(child, 'order'))
+              .map((orderEl) => ({
+                  id: orderEl.getAttribute('id') || null,
+                  label: orderEl.getAttribute('label') || '',
+                  system: orderEl.getAttribute('system') || '',
+                  team: orderEl.getAttribute('team') || '',
+                  status: (orderEl.getAttribute('status') || '').toLowerCase(),
+                  eta: orderEl.getAttribute('eta') || '',
+                  parts: parseParts(orderEl)
+              }))
+        : [];
+
+    return { reports, systems, bypasses, repairs };
+}
+
+function parseParts(orderEl) {
+    const partsRoot = findChild(orderEl, 'parts');
+    if (!partsRoot) {
+        return [];
+    }
+
+    return Array.from(partsRoot.children)
+        .filter((child) => isTag(child, 'part'))
+        .map((partEl) => ({
+            id: partEl.getAttribute('id') || null,
+            name: partEl.getAttribute('name') || '',
+            quantity: toNumber(partEl.getAttribute('quantity'))
+        }));
+}
+
+function parseDamageNode(nodeEl) {
+    const children = Array.from(nodeEl.children)
+        .filter((child) => isTag(child, 'node'))
+        .map((child) => parseDamageNode(child));
+
+    return {
+        id: nodeEl.getAttribute('id') || null,
+        name: nodeEl.getAttribute('name') || '',
+        status: (nodeEl.getAttribute('status') || '').toLowerCase(),
+        integrity: toNumber(nodeEl.getAttribute('integrity')),
+        power: toNumber(nodeEl.getAttribute('power')),
+        note: getChildText(nodeEl, 'note') || '',
+        children
+    };
+}
+
+function isTag(node, name) {
+    return Boolean(node && node.tagName && node.tagName.toLowerCase() === name.toLowerCase());
+}
+
+function findChild(parent, name) {
+    if (!parent) {
+        return null;
+    }
+    return Array.from(parent.children).find((child) => isTag(child, name)) || null;
+}
+
+function getChildText(parent, names) {
+    if (!parent) {
+        return '';
+    }
+    const tags = Array.isArray(names) ? names : [names];
+    for (const tag of tags) {
+        const child = Array.from(parent.children).find((node) => isTag(node, tag));
+        if (child) {
+            return (child.textContent || '').trim();
+        }
+    }
+    return '';
+}
+
+function toNumber(value) {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    const parsed = Number.parseFloat(String(value).replace(',', '.'));
+    return Number.isFinite(parsed) ? parsed : null;
+}


### PR DESCRIPTION
## Summary
- load the default scenario XML for station pages via a new helper module
- surface real reactor output and system consumption data in the reactor station panels
- replace damage control mockups with scenario-driven reports, bypasses and repairs plus supporting styles
- make station rendering async-aware so operations panels can handle async loaders

## Testing
- not run (static site without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cd6d56abc48326a797a7ef0dcb8d56