### PR TITLE
Add offline fallback scenario data for engineering panels

### DIFF
--- a/progress-log.md
+++ b/progress-log.md
@@ -1,0 +1,9 @@
+# Fortschrittsnotizen
+
+## Aktuelle Sitzung
+- Fallback-Datensatz für Szenario-Parser hinzugefügt, damit Stations-Panels (z. B. EN-06 Schadenskontrolle) auch ohne funktionierenden `fetch` mit Statuswerten befüllt werden.
+- Bestehende Parserlogik beibehalten; echte XML-Daten werden weiterhin bevorzugt, Fallback nur bei Ladefehlern aktiv.
+
+## Nächste Schritte / Ideen
+- Prüfen, ob zusätzliche Stationsdaten (z. B. Crewlogistik) ebenfalls eine Offline-Quelle benötigen.
+- Optional: UI-Hinweis ergänzen, wenn Fallback-Daten aktiv sind.


### PR DESCRIPTION
## Summary
- add bundled fallback scenario data so station panels (e.g. EN-06 damage control) render ship status without a working fetch
- keep XML parser as primary source and log when the fallback gets used
- document the progress in a dedicated progress log file

## Testing
- not run (static data update)


------
https://chatgpt.com/codex/tasks/task_e_68cd9071a6748326aa6477780799e8cb