### PR TITLE
Integrate scenario-driven engineering panels

### DIFF
--- a/assets/data/scenario-default.xml
+++ b/assets/data/scenario-default.xml
@@ -156,6 +156,153 @@
                 <bank id="reserve" label="Reservekassetten" status="Standby" saturation="3" saturationUnit="%" timeBuffer="1020" timeBufferUnit="min" />
             </filters>
         </lifeSupport>
+        <engineering>
+            <power>
+                <distribution>
+                    <bus id="power-shields" name="Schilde" value="32" max="45" status="Gefechtsbereit" tone="accent">
+                        <note>Quadrant Beta priorisiert</note>
+                    </bus>
+                    <bus id="power-weapons" name="Waffen" value="26" max="40" status="Ladezyklen stabil" tone="warning">
+                        <note>Reservebus gekoppelt</note>
+                    </bus>
+                    <bus id="power-life" name="Lebenserhaltung" value="12" max="20" status="Nominal" tone="success">
+                        <note>Versorgung Habitat-Ring</note>
+                    </bus>
+                    <bus id="power-eng" name="Engineering Hilfssysteme" value="18" max="25" status="Überwacht" tone="warning">
+                        <note>Aux-Kühlpumpen aktiv</note>
+                    </bus>
+                </distribution>
+                <profiles>
+                    <profile id="profile-cruise" label="Reise (Cruise)">
+                        <description>Stabile Schilde, Fokus auf Lebenserhaltung.</description>
+                    </profile>
+                    <profile id="profile-battle" label="Gefecht" active="true">
+                        <description>Waffen- und Schildleistung priorisieren.</description>
+                    </profile>
+                    <profile id="profile-emergency" label="Notfall">
+                        <description>Lebenserhaltung + Reaktorsicherheit, Rest minimal.</description>
+                    </profile>
+                </profiles>
+                <circuits>
+                    <circuit id="shed-weapons" label="Sekundäre Waffenbanken" enabled="true" tone="warning">
+                        <note>Wird bei Brownout automatisch getrennt.</note>
+                    </circuit>
+                    <circuit id="shed-labs" label="Wissenschaftslabore" enabled="false">
+                        <note>Kann bei längerem Gefecht entkoppelt werden.</note>
+                    </circuit>
+                    <circuit id="shed-hydroponics" label="Hydroponik-Cluster" enabled="false" tone="danger">
+                        <note>Nur im äußersten Notfall deaktivieren.</note>
+                    </circuit>
+                </circuits>
+                <metrics>
+                    <metric id="metric-total-load" label="Gesamtverbrauch" value="87" unit="%" status="warning" note="Schwellwert 90" min="0" max="120" />
+                    <metric id="metric-reserve" label="Reserveleistung" value="14" unit="%" status="critical" note="Unter Soll 18" min="0" max="40" />
+                    <metric id="metric-buffer" label="Pufferkapazität" value="62" unit="%" status="normal" note="Batteriedecks" min="0" max="100" />
+                </metrics>
+                <log>
+                    <entry>05:18 - Brownout-Warnung Deck 4 behoben</entry>
+                    <entry>05:02 - Reservebank 2 geladen (82%)</entry>
+                    <entry>04:47 - Verteiler 7A neu kalibriert</entry>
+                </log>
+            </power>
+            <thermal>
+                <radiators>
+                    <radiator id="rad-alpha" label="Radiator Alpha" value="68" status="warning">
+                        <note>Sonnenexposition hoch</note>
+                    </radiator>
+                    <radiator id="rad-beta" label="Radiator Beta" value="54" status="normal">
+                        <note>Nominal</note>
+                    </radiator>
+                    <radiator id="rad-gamma" label="Radiator Gamma" value="73" status="warning">
+                        <note>Kühlmittelkreislauf prüfen</note>
+                    </radiator>
+                    <radiator id="rad-delta" label="Radiator Delta" value="49" status="normal">
+                        <note>Reserve aktiv</note>
+                    </radiator>
+                </radiators>
+                <loops>
+                    <loop id="loop-primary" label="Primärer Kernkreislauf" pump="76" flow="540" flowUnit="l/min">
+                        <note>Ventil 4 offen</note>
+                    </loop>
+                    <loop id="loop-secondary" label="Sekundärkreislauf" pump="64" flow="410" flowUnit="l/min">
+                        <note>Reserve-Radiator gekoppelt</note>
+                    </loop>
+                    <loop id="loop-aux" label="Auxiliar / Lebenserhaltung" pump="58" flow="320" flowUnit="l/min">
+                        <note>Temperatur stabil</note>
+                    </loop>
+                </loops>
+                <emergencyChecklist>
+                    <item id="venting-ready" label="Radiatoren entfalten / venten vorbereitet" checked="true" />
+                    <item id="heatsinks-arm" label="Heat-Sink-Module geladen">
+                        <note>Letzte Ladung: 28 min</note>
+                    </item>
+                    <item id="purge-lines" label="Kühlmittelleitungen gespült" />
+                    <item id="emergency-fans" label="Notlüfter in Bereitschaft" />
+                </emergencyChecklist>
+                <log>
+                    <entry>05:12 - Radiator Beta wieder im grünen Bereich</entry>
+                    <entry>04:58 - Warnung: Radiator Gamma 72% Last</entry>
+                    <entry>04:41 - Kühlkreislauf Auxiliar entlüftet</entry>
+                </log>
+            </thermal>
+            <propulsion>
+                <throttle id="propulsion-throttle" label="Hauptschub" min="0" max="110" step="5" value="72" unit="%">
+                    <description>Maximale Dauerlast 95%, Nachbrenner bis 110%.</description>
+                </throttle>
+                <deltaV label="Verfügbares Delta-V" value="4.6" unit=" km/s" status="normal" note="Berechnet mit aktueller Masse" min="0" max="12" />
+                <vector>
+                    <axis id="vector-pitch" label="Pitch" min="-30" max="30" step="1" value="2" unit="°" />
+                    <axis id="vector-yaw" label="Yaw" min="-30" max="30" step="1" value="-1" unit="°" />
+                    <axis id="vector-roll" label="Roll" min="-15" max="15" step="1" value="0" unit="°" />
+                </vector>
+                <thrusters>
+                    <thruster id="fore-port" name="Bug • Backbord" active="true" status="Bereit" tone="success" />
+                    <thruster id="fore-starboard" name="Bug • Steuerbord" active="true" status="Bereit" tone="success" />
+                    <thruster id="aft-port" name="Heck • Backbord" active="true" status="Bereit" tone="success" />
+                    <thruster id="aft-starboard" name="Heck • Steuerbord" active="false" status="Service nötig" tone="warning" />
+                    <thruster id="ventral" name="Ventral Cluster" active="true" status="Überwacht" tone="warning" />
+                    <thruster id="dorsal" name="Dorsal Cluster" active="true" status="Bereit" tone="success" />
+                </thrusters>
+                <checklist>
+                    <item id="prop-prime" label="Triebwerke auf Bereitschaft gebracht" checked="true" />
+                    <item id="prop-balance" label="Massenausgleich geprüft">
+                        <note>Cargo bestätigt</note>
+                    </item>
+                    <item id="prop-flightplan" label="Flight-Command bestätigt Manöverfenster" />
+                </checklist>
+            </propulsion>
+            <ftl>
+                <charge label="Aktuelle Ladung" value="62" unit="%" status="warning" note="Sprungbereit ab 95%" min="0" max="100" />
+                <target id="ftl-charge-target" label="Ladeziel" min="80" max="100" step="1" value="95" unit="%" />
+                <stabilityMetrics>
+                    <metric id="stability-field" label="Feldstabilität" value="91" unit="%" status="normal" note="Nominal" min="0" max="100" />
+                    <metric id="stability-jitter" label="Jitter" value="0.6" unit="%" status="warning" note="Grenze 0,8%" min="0" max="3" />
+                    <metric id="stability-struct" label="Strukturbelastung" value="38" unit="%" status="normal" note="Innerhalb Limits" min="0" max="100" />
+                </stabilityMetrics>
+                <stabilityLog>
+                    <entry>05:09 - Navigationsdaten bestätigt</entry>
+                    <entry>05:03 - Feldkalibrierung abgeschlossen</entry>
+                    <entry>04:55 - Sicherheitsinterlock erfolgreich getestet</entry>
+                </stabilityLog>
+                <interlocks>
+                    <interlock id="ftl-lock-captain" label="Captain-Freigabe" defaultChecked="true" tone="accent">
+                        <description>Bestätigung via Brücke</description>
+                    </interlock>
+                    <interlock id="ftl-lock-engineer" label="Chefingenieur" defaultChecked="true" tone="success">
+                        <description>Reaktorleistung gesichert</description>
+                    </interlock>
+                    <interlock id="ftl-lock-navigation" label="Navigation" defaultChecked="false" tone="warning">
+                        <description>Sprungfenster noch in Berechnung</description>
+                    </interlock>
+                </interlocks>
+                <abortPlaceholder>z. B. Signaturanstieg, Kursabweichung, Crew-Feedback</abortPlaceholder>
+                <abortLog>
+                    <entry>04:50 - Sicherheitscheckliste abgeschlossen</entry>
+                    <entry>04:46 - Warnung: Jitter 0,8% (innerhalb Limits)</entry>
+                    <entry>04:38 - Navigation meldet Kursfenster t+11 Minuten</entry>
+                </abortLog>
+            </ftl>
+        </engineering>
     </ship>
     <sectors>
         <sector id="alpha" name="Alpha Quadrant" defaultCoords="A-12-17" baseEta="38" />

--- a/assets/js/station-scenario.js
+++ b/assets/js/station-scenario.js
@@ -427,6 +427,187 @@ const FALLBACK_SCENARIO_DATA = {
                 }
             ]
         }
+    },
+    power: {
+        distribution: [
+            { id: 'power-shields', name: 'Schilde', value: 32, max: 45, status: 'Gefechtsbereit', tone: 'accent' },
+            { id: 'power-weapons', name: 'Waffen', value: 26, max: 40, status: 'Ladezyklen stabil', tone: 'warning' },
+            { id: 'power-life', name: 'Lebenserhaltung', value: 12, max: 20, status: 'Nominal', tone: 'success' },
+            { id: 'power-eng', name: 'Engineering Hilfssysteme', value: 18, max: 25, status: 'Überwacht', tone: 'warning' }
+        ],
+        profiles: [
+            {
+                id: 'profile-cruise',
+                label: 'Reise (Cruise)',
+                description: 'Stabile Schilde, Fokus auf Lebenserhaltung.'
+            },
+            {
+                id: 'profile-battle',
+                label: 'Gefecht',
+                description: 'Waffen- und Schildleistung priorisieren.',
+                active: true
+            },
+            {
+                id: 'profile-emergency',
+                label: 'Notfall',
+                description: 'Lebenserhaltung + Reaktorsicherheit, Rest minimal.'
+            }
+        ],
+        circuits: [
+            {
+                id: 'shed-weapons',
+                label: 'Sekundäre Waffenbanken',
+                defaultChecked: true,
+                description: 'Wird bei Brownout automatisch getrennt.',
+                tone: 'warning'
+            },
+            {
+                id: 'shed-labs',
+                label: 'Wissenschaftslabore',
+                defaultChecked: false,
+                description: 'Kann bei längerem Gefecht entkoppelt werden.',
+                tone: 'default'
+            },
+            {
+                id: 'shed-hydroponics',
+                label: 'Hydroponik-Cluster',
+                defaultChecked: false,
+                description: 'Nur im äußersten Notfall deaktivieren.',
+                tone: 'danger'
+            }
+        ],
+        metrics: [
+            { label: 'Gesamtverbrauch', value: 87, unit: '%', status: 'warning', note: 'Schwellwert 90%', min: 0, max: 120 },
+            { label: 'Reserveleistung', value: 14, unit: '%', status: 'critical', note: 'Unter Soll 18%', min: 0, max: 40 },
+            { label: 'Pufferkapazität', value: 62, unit: '%', status: 'normal', note: 'Batteriedecks', min: 0, max: 100 }
+        ],
+        log: [
+            '05:18 - Brownout-Warnung Deck 4 behoben',
+            '05:02 - Reservebank 2 geladen (82%)',
+            '04:47 - Verteiler 7A neu kalibriert'
+        ]
+    },
+    thermal: {
+        radiators: [
+            { label: 'Radiator Alpha', value: 68, status: 'warning', note: 'Sonnenexposition hoch' },
+            { label: 'Radiator Beta', value: 54, status: 'normal', note: 'Nominal' },
+            { label: 'Radiator Gamma', value: 73, status: 'warning', note: 'Kühlmittelkreislauf prüfen' },
+            { label: 'Radiator Delta', value: 49, status: 'normal', note: 'Reserve aktiv' }
+        ],
+        loops: [
+            { id: 'loop-primary', name: 'Primärer Kernkreislauf', pump: 76, flow: 540, note: 'Ventil 4 offen' },
+            { id: 'loop-secondary', name: 'Sekundärkreislauf', pump: 64, flow: 410, note: 'Reserve-Radiator gekoppelt' },
+            { id: 'loop-aux', name: 'Auxiliar / Lebenserhaltung', pump: 58, flow: 320, note: 'Temperatur stabil' }
+        ],
+        emergencyChecklist: [
+            { id: 'venting-ready', label: 'Radiatoren entfalten / venten vorbereitet', checked: true },
+            { id: 'heatsinks-arm', label: 'Heat-Sink-Module geladen', note: 'Letzte Ladung: 28 min' },
+            { id: 'purge-lines', label: 'Kühlmittelleitungen gespült' },
+            { id: 'emergency-fans', label: 'Notlüfter in Bereitschaft' }
+        ],
+        log: [
+            '05:12 - Radiator Beta wieder im grünen Bereich',
+            '04:58 - Warnung: Radiator Gamma 72% Last',
+            '04:41 - Kühlkreislauf Auxiliar entlüftet'
+        ]
+    },
+    propulsion: {
+        throttle: {
+            id: 'propulsion-throttle',
+            label: 'Hauptschub',
+            min: 0,
+            max: 110,
+            step: 5,
+            value: 72,
+            unit: '%',
+            description: 'Maximale Dauerlast 95%, Nachbrenner bis 110%.'
+        },
+        deltaV: {
+            label: 'Verfügbares Delta-V',
+            value: 4.6,
+            unit: ' km/s',
+            status: 'normal',
+            note: 'Berechnet mit aktueller Masse',
+            min: 0,
+            max: 12
+        },
+        vectorAxes: [
+            { id: 'vector-pitch', label: 'Pitch', min: -30, max: 30, step: 1, value: 2, unit: '°' },
+            { id: 'vector-yaw', label: 'Yaw', min: -30, max: 30, step: 1, value: -1, unit: '°' },
+            { id: 'vector-roll', label: 'Roll', min: -15, max: 15, step: 1, value: 0, unit: '°' }
+        ],
+        thrusters: [
+            { id: 'fore-port', name: 'Bug • Backbord', active: true, status: 'Bereit', tone: 'success' },
+            { id: 'fore-starboard', name: 'Bug • Steuerbord', active: true, status: 'Bereit', tone: 'success' },
+            { id: 'aft-port', name: 'Heck • Backbord', active: true, status: 'Bereit', tone: 'success' },
+            { id: 'aft-starboard', name: 'Heck • Steuerbord', active: false, status: 'Service nötig', tone: 'warning' },
+            { id: 'ventral', name: 'Ventral Cluster', active: true, status: 'Überwacht', tone: 'warning' },
+            { id: 'dorsal', name: 'Dorsal Cluster', active: true, status: 'Bereit', tone: 'success' }
+        ],
+        checklist: [
+            { id: 'prop-prime', label: 'Triebwerke auf Bereitschaft gebracht', checked: true },
+            { id: 'prop-balance', label: 'Massenausgleich geprüft', note: 'Cargo bestätigt' },
+            { id: 'prop-flightplan', label: 'Flight-Command bestätigt Manöverfenster' }
+        ]
+    },
+    ftl: {
+        charge: {
+            label: 'Aktuelle Ladung',
+            value: 62,
+            unit: '%',
+            status: 'warning',
+            note: 'Sprungbereit ab 95%',
+            min: 0,
+            max: 100
+        },
+        target: {
+            id: 'ftl-charge-target',
+            label: 'Ladeziel',
+            min: 80,
+            max: 100,
+            step: 1,
+            value: 95,
+            unit: '%'
+        },
+        stabilityMetrics: [
+            { label: 'Feldstabilität', value: 91, unit: '%', status: 'normal', note: 'Nominal', min: 0, max: 100 },
+            { label: 'Jitter', value: 0.6, unit: '%', status: 'warning', note: 'Grenze 0,8%', min: 0, max: 3 },
+            { label: 'Strukturbelastung', value: 38, unit: '%', status: 'normal', note: 'Innerhalb Limits', min: 0, max: 100 }
+        ],
+        stabilityLog: [
+            '05:09 - Navigationsdaten bestätigt',
+            '05:03 - Feldkalibrierung abgeschlossen',
+            '04:55 - Sicherheitsinterlock erfolgreich getestet'
+        ],
+        interlocks: [
+            {
+                id: 'ftl-lock-captain',
+                label: 'Captain-Freigabe',
+                defaultChecked: true,
+                tone: 'accent',
+                description: 'Bestätigung via Brücke'
+            },
+            {
+                id: 'ftl-lock-engineer',
+                label: 'Chefingenieur',
+                defaultChecked: true,
+                tone: 'success',
+                description: 'Reaktorleistung gesichert'
+            },
+            {
+                id: 'ftl-lock-navigation',
+                label: 'Navigation',
+                defaultChecked: false,
+                tone: 'warning',
+                description: 'Sprungfenster noch in Berechnung'
+            }
+        ],
+        abortPlaceholder: 'z. B. Signaturanstieg, Kursabweichung, Crew-Feedback',
+        abortLog: [
+            '04:50 - Sicherheitscheckliste abgeschlossen',
+            '04:46 - Warnung: Jitter 0,8% (innerhalb Limits)',
+            '04:38 - Navigation meldet Kursfenster t+11 Minuten'
+        ]
     }
 };
 
@@ -470,7 +651,11 @@ function parseScenarioXml(xmlText) {
     return {
         systems: parseSystems(doc),
         damageControl: parseDamageControl(doc),
-        lifeSupport: parseLifeSupport(doc)
+        lifeSupport: parseLifeSupport(doc),
+        power: parseEngineeringPower(doc),
+        thermal: parseEngineeringThermal(doc),
+        propulsion: parseEngineeringPropulsion(doc),
+        ftl: parseEngineeringFtl(doc)
     };
 }
 
@@ -659,6 +844,229 @@ function parseLifeSupport(doc) {
     return { sections, leaks, filters };
 }
 
+function parseEngineeringPower(doc) {
+    const powerRoot = doc.querySelector('scenario > ship > engineering > power');
+    if (!powerRoot) {
+        return null;
+    }
+
+    const distribution = Array.from(powerRoot.querySelectorAll('distribution > bus')).map((busEl) => ({
+        id: busEl.getAttribute('id') || null,
+        name: busEl.getAttribute('name') || '',
+        value: toNumber(busEl.getAttribute('value')),
+        min: toNumber(busEl.getAttribute('min')),
+        max: toNumber(busEl.getAttribute('max')),
+        step: toNumber(busEl.getAttribute('step')),
+        unit: busEl.getAttribute('unit') || '%',
+        status: busEl.getAttribute('status') || '',
+        tone: safeLower(busEl.getAttribute('tone')) || undefined,
+        description: busEl.getAttribute('description') || getChildText(busEl, 'description') || '',
+        note: getChildText(busEl, 'note') || ''
+    }));
+
+    const profiles = Array.from(powerRoot.querySelectorAll('profiles > profile')).map((profileEl) => ({
+        id: profileEl.getAttribute('id') || null,
+        label: profileEl.getAttribute('label') || profileEl.getAttribute('name') || '',
+        description: profileEl.getAttribute('description') || getChildText(profileEl, 'description') || '',
+        note: getChildText(profileEl, 'note') || '',
+        active: parseBoolean(profileEl.getAttribute('active'))
+    }));
+
+    const circuits = Array.from(powerRoot.querySelectorAll('circuits > circuit')).map((circuitEl) => ({
+        id: circuitEl.getAttribute('id') || null,
+        label: circuitEl.getAttribute('label') || '',
+        defaultChecked: parseBoolean(
+            circuitEl.getAttribute('defaultChecked') ||
+                circuitEl.getAttribute('enabled') ||
+                circuitEl.getAttribute('armed')
+        ),
+        tone: safeLower(circuitEl.getAttribute('tone')) || 'default',
+        description: circuitEl.getAttribute('description') || getChildText(circuitEl, 'description') || '',
+        note: getChildText(circuitEl, 'note') || ''
+    }));
+
+    const metrics = Array.from(powerRoot.querySelectorAll('metrics > metric'))
+        .map((metricEl) => parseMetricElement(metricEl))
+        .filter(Boolean);
+
+    const log = parseLogEntries(powerRoot.querySelectorAll('log > entry'));
+
+    return { distribution, profiles, circuits, metrics, log };
+}
+
+function parseEngineeringThermal(doc) {
+    const thermalRoot = doc.querySelector('scenario > ship > engineering > thermal');
+    if (!thermalRoot) {
+        return null;
+    }
+
+    const radiators = Array.from(thermalRoot.querySelectorAll('radiators > radiator')).map((radiatorEl) => ({
+        id: radiatorEl.getAttribute('id') || null,
+        label: radiatorEl.getAttribute('label') || radiatorEl.getAttribute('name') || '',
+        value: toNumber(radiatorEl.getAttribute('value')),
+        unit: radiatorEl.getAttribute('unit') || '%',
+        status: safeLower(radiatorEl.getAttribute('status') || radiatorEl.getAttribute('tone')) || 'normal',
+        note: radiatorEl.getAttribute('note') || getChildText(radiatorEl, 'note') || '',
+        min: toNumber(radiatorEl.getAttribute('min')),
+        max: toNumber(radiatorEl.getAttribute('max'))
+    }));
+
+    const loops = Array.from(thermalRoot.querySelectorAll('loops > loop')).map((loopEl) => ({
+        id: loopEl.getAttribute('id') || null,
+        name: loopEl.getAttribute('label') || loopEl.getAttribute('name') || '',
+        pump: toNumber(loopEl.getAttribute('pump')),
+        flow: toNumber(loopEl.getAttribute('flow')),
+        flowUnit: loopEl.getAttribute('flowUnit') || loopEl.getAttribute('flowunit') || 'l/min',
+        min: toNumber(loopEl.getAttribute('min')),
+        max: toNumber(loopEl.getAttribute('max')),
+        step: toNumber(loopEl.getAttribute('step')),
+        unit: loopEl.getAttribute('unit') || '%',
+        status: loopEl.getAttribute('status') || '',
+        statusLabel: loopEl.getAttribute('statusLabel') || loopEl.getAttribute('statuslabel') || '',
+        statusTone: safeLower(loopEl.getAttribute('tone') || loopEl.getAttribute('statusTone')) || '',
+        description: loopEl.getAttribute('description') || getChildText(loopEl, 'description') || '',
+        note: getChildText(loopEl, 'note') || ''
+    }));
+
+    const emergencyChecklistRoot = thermalRoot.querySelector('emergencyChecklist');
+    const emergencyChecklist = emergencyChecklistRoot
+        ? Array.from(emergencyChecklistRoot.querySelectorAll('item')).map((itemEl) => ({
+              id: itemEl.getAttribute('id') || null,
+              label: itemEl.getAttribute('label') || '',
+              checked: parseBoolean(itemEl.getAttribute('checked') || itemEl.getAttribute('completed')),
+              note: itemEl.getAttribute('note') || getChildText(itemEl, 'note') || ''
+          }))
+        : [];
+
+    const log = parseLogEntries(thermalRoot.querySelectorAll('log > entry'));
+
+    return { radiators, loops, emergencyChecklist, log };
+}
+
+function parseEngineeringPropulsion(doc) {
+    const propulsionRoot = doc.querySelector('scenario > ship > engineering > propulsion');
+    if (!propulsionRoot) {
+        return null;
+    }
+
+    const throttleEl = propulsionRoot.querySelector('throttle');
+    const throttle = throttleEl
+        ? {
+              id: throttleEl.getAttribute('id') || null,
+              label: throttleEl.getAttribute('label') || '',
+              min: toNumber(throttleEl.getAttribute('min')),
+              max: toNumber(throttleEl.getAttribute('max')),
+              step: toNumber(throttleEl.getAttribute('step')),
+              value: toNumber(throttleEl.getAttribute('value')),
+              unit: throttleEl.getAttribute('unit') || '%',
+              description: throttleEl.getAttribute('description') || getChildText(throttleEl, 'description') || ''
+          }
+        : null;
+
+    const deltaVEl = propulsionRoot.querySelector('deltaV');
+    const deltaV = deltaVEl
+        ? {
+              label: deltaVEl.getAttribute('label') || '',
+              value: toNumber(deltaVEl.getAttribute('value')),
+              unit: deltaVEl.getAttribute('unit') || '',
+              status: safeLower(deltaVEl.getAttribute('status')) || 'normal',
+              note: deltaVEl.getAttribute('note') || getChildText(deltaVEl, 'note') || '',
+              min: toNumber(deltaVEl.getAttribute('min')),
+              max: toNumber(deltaVEl.getAttribute('max'))
+          }
+        : null;
+
+    const vectorAxes = Array.from(propulsionRoot.querySelectorAll('vector > axis')).map((axisEl) => ({
+        id: axisEl.getAttribute('id') || null,
+        label: axisEl.getAttribute('label') || '',
+        min: toNumber(axisEl.getAttribute('min')),
+        max: toNumber(axisEl.getAttribute('max')),
+        step: toNumber(axisEl.getAttribute('step')),
+        value: toNumber(axisEl.getAttribute('value')),
+        unit: axisEl.getAttribute('unit') || ''
+    }));
+
+    const thrusters = Array.from(propulsionRoot.querySelectorAll('thrusters > thruster')).map((thrusterEl) => ({
+        id: thrusterEl.getAttribute('id') || null,
+        name: thrusterEl.getAttribute('name') || thrusterEl.getAttribute('label') || '',
+        active: parseBoolean(thrusterEl.getAttribute('active') || thrusterEl.getAttribute('enabled')),
+        status: thrusterEl.getAttribute('status') || '',
+        tone: safeLower(thrusterEl.getAttribute('tone')) || undefined,
+        onLabel: thrusterEl.getAttribute('onLabel') || thrusterEl.getAttribute('onlabel') || '',
+        offLabel: thrusterEl.getAttribute('offLabel') || thrusterEl.getAttribute('offlabel') || '',
+        note: getChildText(thrusterEl, 'note') || ''
+    }));
+
+    const checklist = Array.from(propulsionRoot.querySelectorAll('checklist > item')).map((itemEl) => ({
+        id: itemEl.getAttribute('id') || null,
+        label: itemEl.getAttribute('label') || '',
+        checked: parseBoolean(itemEl.getAttribute('checked') || itemEl.getAttribute('completed')),
+        note: itemEl.getAttribute('note') || getChildText(itemEl, 'note') || ''
+    }));
+
+    return { throttle, deltaV, vectorAxes, thrusters, checklist };
+}
+
+function parseEngineeringFtl(doc) {
+    const ftlRoot = doc.querySelector('scenario > ship > engineering > ftl');
+    if (!ftlRoot) {
+        return null;
+    }
+
+    const chargeEl = ftlRoot.querySelector('charge');
+    const charge = chargeEl
+        ? {
+              label: chargeEl.getAttribute('label') || '',
+              value: toNumber(chargeEl.getAttribute('value')),
+              unit: chargeEl.getAttribute('unit') || '%',
+              status: safeLower(chargeEl.getAttribute('status')) || 'normal',
+              note: chargeEl.getAttribute('note') || getChildText(chargeEl, 'note') || '',
+              min: toNumber(chargeEl.getAttribute('min')),
+              max: toNumber(chargeEl.getAttribute('max'))
+          }
+        : null;
+
+    const targetEl = ftlRoot.querySelector('target');
+    const target = targetEl
+        ? {
+              id: targetEl.getAttribute('id') || null,
+              label: targetEl.getAttribute('label') || '',
+              min: toNumber(targetEl.getAttribute('min')),
+              max: toNumber(targetEl.getAttribute('max')),
+              step: toNumber(targetEl.getAttribute('step')),
+              value: toNumber(targetEl.getAttribute('value')),
+              unit: targetEl.getAttribute('unit') || '%',
+              description: targetEl.getAttribute('description') || getChildText(targetEl, 'description') || ''
+          }
+        : null;
+
+    const stabilityMetrics = Array.from(ftlRoot.querySelectorAll('stabilityMetrics > metric'))
+        .map((metricEl) => parseMetricElement(metricEl))
+        .filter(Boolean);
+
+    const stabilityLog = parseLogEntries(ftlRoot.querySelectorAll('stabilityLog > entry'));
+
+    const interlocks = Array.from(ftlRoot.querySelectorAll('interlocks > interlock')).map((interlockEl) => ({
+        id: interlockEl.getAttribute('id') || null,
+        label: interlockEl.getAttribute('label') || '',
+        defaultChecked: parseBoolean(
+            interlockEl.getAttribute('defaultChecked') ||
+                interlockEl.getAttribute('enabled') ||
+                interlockEl.getAttribute('active')
+        ),
+        tone: safeLower(interlockEl.getAttribute('tone')) || 'default',
+        description: interlockEl.getAttribute('description') || getChildText(interlockEl, 'description') || '',
+        note: getChildText(interlockEl, 'note') || ''
+    }));
+
+    const abortPlaceholder =
+        getChildText(ftlRoot, 'abortPlaceholder') || ftlRoot.getAttribute('abortPlaceholder') || '';
+
+    const abortLog = parseLogEntries(ftlRoot.querySelectorAll('abortLog > entry'));
+
+    return { charge, target, stabilityMetrics, stabilityLog, interlocks, abortPlaceholder, abortLog };
+}
+
 function parseDamageNode(nodeEl) {
     const children = Array.from(nodeEl.children)
         .filter((child) => isTag(child, 'node'))
@@ -698,6 +1106,54 @@ function getChildText(parent, names) {
         }
     }
     return '';
+}
+
+function parseMetricElement(metricEl) {
+    if (!metricEl) {
+        return null;
+    }
+    return {
+        id: metricEl.getAttribute('id') || null,
+        label: metricEl.getAttribute('label') || '',
+        value: toNumber(metricEl.getAttribute('value')),
+        unit: metricEl.getAttribute('unit') || '',
+        status: safeLower(metricEl.getAttribute('status')) || 'normal',
+        note: metricEl.getAttribute('note') || getChildText(metricEl, 'note') || '',
+        min: toNumber(metricEl.getAttribute('min')),
+        max: toNumber(metricEl.getAttribute('max'))
+    };
+}
+
+function parseLogEntries(nodeList) {
+    if (!nodeList) {
+        return [];
+    }
+    return Array.from(nodeList)
+        .map((entry) => (entry.textContent || '').trim())
+        .filter((text) => text.length > 0);
+}
+
+function parseBoolean(value) {
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) {
+            return null;
+        }
+        if (['true', '1', 'yes', 'on', 'active', 'enabled', 'ja'].includes(normalized)) {
+            return true;
+        }
+        if (['false', '0', 'no', 'off', 'inactive', 'disabled', 'nein'].includes(normalized)) {
+            return false;
+        }
+        return null;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    return null;
 }
 
 function toNumber(value) {

--- a/progress-log.md
+++ b/progress-log.md
@@ -3,6 +3,8 @@
 ## Aktuelle Sitzung
 - Fallback-Datensatz für Szenario-Parser hinzugefügt, damit Stations-Panels (z. B. EN-06 Schadenskontrolle) auch ohne funktionierenden `fetch` mit Statuswerten befüllt werden.
 - Bestehende Parserlogik beibehalten; echte XML-Daten werden weiterhin bevorzugt, Fallback nur bei Ladefehlern aktiv.
+- Engineering-Konsolen (Reaktor, Energie, Thermik, Antrieb, FTL) lesen nun Leistungs-, Status- und Protokolldaten direkt aus dem Szenario (XML & Fallback) statt statischer Werte.
+- Szenario-Parser und `scenario-default.xml` um die Bereiche `<engineering>` → `<power>`, `<thermal>`, `<propulsion>` und `<ftl>` ergänzt, sodass alle Maschinenraum-Panels Schiffs-spezifische Kennzahlen anzeigen.
 
 ## Nächste Schritte / Ideen
 - Prüfen, ob zusätzliche Stationsdaten (z. B. Crewlogistik) ebenfalls eine Offline-Quelle benötigen.


### PR DESCRIPTION
## Summary
- load power, thermal, propulsion and FTL station panels with values sourced from the active scenario data
- extend the scenario parser and fallback dataset to support new engineering sections and metrics
- enrich the default scenario XML with engineering distributions, loops, thrusters and logs for immersive readouts
- capture progress updates describing the new scenario-backed engineering consoles

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd9eb598088326bbfd4468ce7c44cb