### PR TITLE
Add engineering status overviews to reactor and damage control panels

### DIFF
--- a/engineering-progress.md
+++ b/engineering-progress.md
@@ -1,6 +1,8 @@
 # Engineering Stations Fortschritt
 
 ## Aktuelle Sitzung
+- EN-01 "Reaktorkontrolle": Netzbelastung & Reservekennzahlen in eigenes Panel übernommen, damit Bediencrew Reaktorleistung zum Gesamtnetz abgleichen kann.
+- EN-06 "Schadenskontrolle & Leitungen": Maschinenraumlage mit Energie- und Thermalkennzahlen ergänzt, um Lageberichte mit Livewerten zu unterstützen.
 - EN-06 "Schadenskontrolle & Leitungen": Interaktive Panels für Sektionsstatus, Lecküberwachung, Leitungsnetz, Filterverwaltung und Lagerbestände umgesetzt.
 - Szenariodaten erweitert, damit die Panels mit Schiffs- und Stationswerten befüllt werden können.
 - UI-Stile ergänzt, um die neuen Anzeigen konsistent mit dem bestehenden Look & Feel darzustellen.

--- a/progress-log.md
+++ b/progress-log.md
@@ -1,6 +1,7 @@
 # Fortschrittsnotizen
 
 ## Aktuelle Sitzung
+- Maschinenraum-Panels für EN-01 (Reaktorkontrolle) und EN-06 (Schadenskontrolle & Leitungen) um Lageübersichten erweitert: Netzbelastung, Reserven sowie Thermalkreise werden jetzt direkt aus den Szenariodaten angezeigt.
 - Verteidigungs-Szenariodaten (Schilde & Hülle) in Fallback und XML ergänzt, inklusive Sektorstatus, Verstärkungseinstellungen, Notfallbarrieren und struktureller Hotspots.
 - Parser (`station-scenario.js`) um `parseDefense` erweitert, damit Schild- und Hüllenstationen ihre Panels aus dem Szenario speisen.
 - Interaktive Panels für `def-shields` und `def-hull` umgesetzt: Sektormetriken, Verstärkungssteuerung, Barrieren, taktische Prioritäten, Schott-/Verstrebungsübersichten sowie Resonanzwarnungen.


### PR DESCRIPTION
## Summary
- surface machine room metrics on EN-06 damage control so crews can brief with live power and thermal data
- expose network load and reserve readings on the EN-01 reactor console using the parsed scenario metrics
- document the new coverage in the engineering progress notes and overall progress log

## Testing
- not run (UI/data updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cdb14b92d083268c4c4a68b449ef58